### PR TITLE
Fix "dropped" unread message

### DIFF
--- a/webwhatsapi/js_scripts/get_unread_messages.js
+++ b/webwhatsapi/js_scripts/get_unread_messages.js
@@ -1,5 +1,16 @@
 var Chats = Store.Chat.models;
 var Output = [];
+
+function isChatMessage(message) {
+    if (message.__x_isNotification) {
+        return false;
+    }
+    if (!message.__x_isUserCreatedType) {
+        return false;
+    }
+    return true;
+}
+
 for (chat in Chats) {
     if (isNaN(chat)) {
         continue;
@@ -13,6 +24,9 @@ for (chat in Chats) {
         if (!messages[i].__x_isNewMsg) {
             break;
         } else {
+            if (!isChatMessage(messages[i])) {
+                continue
+            }
             messages[i].__x_isNewMsg = false;
             temp.messages.push({
                 message: messages[i].__x_body,

--- a/webwhatsapi/js_scripts/get_unread_messages.js
+++ b/webwhatsapi/js_scripts/get_unread_messages.js
@@ -1,13 +1,4 @@
 var Chats = Store.Chat.models;
-if (!('last_read' in window)) {
-    window.last_read = {};
-    for (chat in Chats) {
-        if (isNaN(chat)) {
-        continue;
-        };
-        window.last_read[Chats[chat].__x_formattedTitle] = Math.floor(Date.now() / 1000);
-    }
-}
 var Output = [];
 for (chat in Chats) {
     if (isNaN(chat)) {
@@ -19,11 +10,12 @@ for (chat in Chats) {
     temp.messages = [];
     var messages = Chats[chat].msgs.models;
     for (var i=messages.length-1;i>=0;i--) {
-        if (messages[i].__x_t <= last_read[Chats[chat].__x_formattedTitle] || messages[i].id.fromMe==true) {
+        if (!messages[i].__x_isNewMsg) {
             console.log("no");
             break;
         } else {
             console.log("yes");
+            messages[i].__x_isNewMsg = false;
             temp.messages.push(
                 {
                     message: messages[i].__x_body,
@@ -32,7 +24,6 @@ for (chat in Chats) {
             );
         }
     }
-    last_read[Chats[chat].__x_formattedTitle] = Math.floor(Date.now() / 1000);
     if(temp.messages.length>0)
         Output.push(temp);
 }

--- a/webwhatsapi/js_scripts/get_unread_messages.js
+++ b/webwhatsapi/js_scripts/get_unread_messages.js
@@ -9,23 +9,20 @@ for (chat in Chats) {
     temp.id = Chats[chat].__x_id;
     temp.messages = [];
     var messages = Chats[chat].msgs.models;
-    for (var i=messages.length-1;i>=0;i--) {
+    for (var i = messages.length - 1; i >= 0; i--) {
         if (!messages[i].__x_isNewMsg) {
-            console.log("no");
             break;
         } else {
-            console.log("yes");
             messages[i].__x_isNewMsg = false;
-            temp.messages.push(
-                {
-                    message: messages[i].__x_body,
-                    timestamp: messages[i].__x_t
-                }
-            );
+            temp.messages.push({
+                message: messages[i].__x_body,
+                timestamp: messages[i].__x_t
+            });
         }
     }
-    if(temp.messages.length>0)
+    if(temp.messages.length > 0) {
         Output.push(temp);
+    }
 }
-console.log("hi", Output);
+console.log("Unread messages: ", Output);
 return Output;


### PR DESCRIPTION
This patch 

- Fix a bug where unread message not shown up if it come in **under 1 second** of last checked time.
- Checking if it really a user sent messages (don't send scam/block banner)